### PR TITLE
[fix] ログイン済みのユーザによる操作に限定

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -1,5 +1,6 @@
 class EventsController < ApplicationController
   before_action :set_event, only: [:show, :edit, :update, :destroy]
+  before_action :authenticate_user!, only: [:new, :edit]
 
   # GET /events
   # GET /events.json

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -19,6 +19,8 @@
   <strong>End time:</strong>
   <%= @event.end_time %>
 </p>
+<% if user_signed_in? %>
+  <%= link_to 'Edit', edit_event_path(@event) %> |
+<% end %>
 
-<%= link_to 'Edit', edit_event_path(@event) %> |
 <%= link_to 'Back', root_path %>


### PR DESCRIPTION
新規イベントの追加、イベントの編集を制限